### PR TITLE
Fix listen address parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Also, you can grab latest release from [here](https://github.com/x1unix/telshell
 ## Usage
 
 ```bash
-./telshell -listen=:5000
+./telshell -addr=:5000
 ```
 
 We also recommend `-s=-i` argument to start shell in *interactive* mode


### PR DESCRIPTION
With the [latest release](https://github.com/x1unix/telshell/releases/latest) it's now `-addr` instead of `-listen` but the README still states the latter.